### PR TITLE
Fix push_to_pulp with a repo_prefix

### DIFF
--- a/dockpulp/__init__.py
+++ b/dockpulp/__init__.py
@@ -624,7 +624,8 @@ class Pulp(object):
                 #print kwargs
             self.createRepo(repo, "/pulp/docker/%s" % repo,
                             registry_id=mod_repos_tags_mapping[repo]["registry-id"],
-                            desc=kwargs.get("desc"), title=kwargs.get("title"))
+                            desc=kwargs.get("desc"), title=kwargs.get("title"),
+                            prefix_with=repo_prefix)
 
         top_layer = imgutils.get_top_layer(pulp_md)
         self.upload(tarfile)


### PR DESCRIPTION
Can you please bring this fix into the branch we use in our build images? It is needed for scratch builds functionality. Note it is in release-engineering/dockpulp master if you want to pick it from there.
